### PR TITLE
Update package.json: devs: mockttp ^3.8.0 -> ^3.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "jest": "^29.6.1",
     "lint-staged": "^13.2.3",
     "lockfile-lint": "^4.10.6",
-    "mockttp": "^3.8.0",
+    "mockttp": "^3.9.1",
     "prettier": "^2.8.8",
     "typescript": "^5.1.6"
   },


### PR DESCRIPTION
Removes indirect dependency on vulnerable vm2 package. https://github.com/advisories/GHSA-cchq-frgv-rjh5